### PR TITLE
Fix a nonexistent variable `self.model` -> `self._model`

### DIFF
--- a/src/ydata_synthetic/synthesizers/regular/vanillagan/model.py
+++ b/src/ydata_synthetic/synthesizers/regular/vanillagan/model.py
@@ -85,7 +85,7 @@ class VanilllaGAN(gan.Model):
             # ---------------------
             noise = tf.random.normal((self.batch_size, self.noise_dim))
             # Train the generator (to have the discriminator label samples as valid)
-            g_loss = self.model.train_on_batch(noise, valid)
+            g_loss = self._model.train_on_batch(noise, valid)
 
             # Plot the progress
             print("%d [D loss: %f, acc.: %.2f%%] [G loss: %f]" % (epoch, d_loss[0], 100 * d_loss[1], g_loss))

--- a/src/ydata_synthetic/synthesizers/regular/wgan/model.py
+++ b/src/ydata_synthetic/synthesizers/regular/wgan/model.py
@@ -117,7 +117,7 @@ class WGAN(gan.Model):
                 # ---------------------
                 noise = tf.random.normal((self.batch_size, self.noise_dim))
                 # Train the generator (to have the critic label samples as valid)
-                g_loss = self.model.train_on_batch(noise, valid)
+                g_loss = self._model.train_on_batch(noise, valid)
                 # Plot the progress
                 print("%d [D loss: %f, acc.: %.2f%%] [G loss: %f]" % (epoch, d_loss[0], 100 * d_loss[1], g_loss))
 


### PR DESCRIPTION
Hi, I've found a typo in the `train` method. The example notebook won't run because of this.