### PR TITLE
chore: make GP loss consistent with __MODEL__ attribute

### DIFF
--- a/src/ydata_synthetic/synthesizers/loss.py
+++ b/src/ydata_synthetic/synthesizers/loss.py
@@ -5,9 +5,9 @@ from tensorflow import norm as tfnorm
 from enum import Enum
 
 class Mode(Enum):
-    WGANGP = 'wgangp'
+    WGAN_GP = 'wgangp'
     DRAGAN = 'dragan'
-    CRAMER = 'cramer'
+    CRAMERGAN = 'cramer'
 
 ## Original code loss from
 ## https://github.com/LynnHo/DCGAN-LSGAN-WGAN-GP-DRAGAN-Tensorflow-2/blob/master/tf2gan/loss.py
@@ -45,9 +45,9 @@ def gradient_penalty(f, real, fake, mode):
 
     if mode == Mode.DRAGAN:
         gp = _gradient_penalty(f, real)
-    elif mode == Mode.CRAMER:
+    elif mode == Mode.CRAMERGAN:
         gp = _gradient_penalty_cramer(f, real, fake)
-    elif mode == Mode.WGANGP:
+    elif mode == Mode.WGAN_GP:
         gp = _gradient_penalty(f, real, fake)
 
     return gp

--- a/src/ydata_synthetic/synthesizers/regular/cramergan/model.py
+++ b/src/ydata_synthetic/synthesizers/regular/cramergan/model.py
@@ -40,7 +40,7 @@ class CRAMERGAN(BaseModel):
         logits = self.critic(fake)
 
     def gradient_penalty(self, real, fake):
-        gp = gradient_penalty(self.f_crit, real, fake, mode=Mode.CRAMER)
+        gp = gradient_penalty(self.f_crit, real, fake, mode=Mode[self.__MODEL__])
         return gp
 
     def update_gradients(self, x):


### PR DESCRIPTION
`__MODEL__` is an attribute defined on class level, which could be leveraged in the enum classes instead to avoid unnecessary customization on top of the base model.