### PR TITLE
fix(TimeGAN): Restore define_gan call

### DIFF
--- a/src/ydata_synthetic/synthesizers/timeseries/timegan/model.py
+++ b/src/ydata_synthetic/synthesizers/timeseries/timegan/model.py
@@ -226,6 +226,9 @@ class TimeGAN(BaseModel):
                                 .repeat())
 
     def train(self, data, train_steps):
+        # Assemble the model
+        self.define_gan()
+
         ## Embedding network training
         autoencoder_opt = Adam(learning_rate=self.g_lr)
         for _ in tqdm(range(train_steps), desc='Emddeding network training'):


### PR DESCRIPTION
Restores the missing define_gan method call after the previous BaseModel init/train methods refactor.