### PR TITLE
feat: add Fabric Regular Synthesizer to Streamlit app

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,10 +50,10 @@ setup(name='ydata-synthetic',
       install_requires=requirements,
       extras_require={
           "streamlit": [
-              "streamlit==0.18.1",
               "typing-extensions==3.10.0",
               "streamlit_pandas_profiling==0.1.3",
-              "ydata-profiling==4.0.0"
+              "ydata-profiling==4.0.0",
+              #"ydata-sdk==0.2.0"
           ],
       },
       )

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(name='ydata-synthetic',
       install_requires=requirements,
       extras_require={
           "streamlit": [
+              "streamlit==1.18.1",
               "typing-extensions==3.10.0",
               "streamlit_pandas_profiling==0.1.3",
               "ydata-profiling==4.0.0",

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name='ydata-synthetic',
               "typing-extensions==3.10.0",
               "streamlit_pandas_profiling==0.1.3",
               "ydata-profiling==4.0.0",
-              #"ydata-sdk==0.2.0"
+              "ydata-sdk>=0.2.1"
           ],
       },
       )

--- a/src/ydata_synthetic/streamlit_app/About.py
+++ b/src/ydata_synthetic/streamlit_app/About.py
@@ -44,6 +44,15 @@ def main():
     - WGAN
     - WGANGP
     - CTGAN
+    - **ydata-sdk Synthesizer**
+    ''')
+
+    st.success('''In particular, **ydata-sdk Synthesizer** uses [`ydata-sdk`](https://docs.sdk.ydata.ai/) to leverage the state-of-the-art synthesizer model developed by YData.''')
+    st.info('''
+    Using **ydata-sdk Synthesizer** requires a valid token. The token is attached to a Fabric account.   
+    In case you do not have an account, you can create one at https://ydata.ai/ydata-fabric-free-trial.    
+    To obtain the token, please, login to https://fabric.ydata.ai.    
+    The token is available on the homepage once you are connected.
     ''')
 
     #best practives for synthetic data generation

--- a/src/ydata_synthetic/streamlit_app/pages/1_Train_a_synthesizer.py
+++ b/src/ydata_synthetic/streamlit_app/pages/1_Train_a_synthesizer.py
@@ -98,7 +98,7 @@ def run():
                     get_client()
                     st.text('✅ Valid')
                     valid_token = True
-                except:
+                except Exception:
                     st.text('❌ Invalid')
 
             if not valid_token:

--- a/src/ydata_synthetic/streamlit_app/pages/1_Train_a_synthesizer.py
+++ b/src/ydata_synthetic/streamlit_app/pages/1_Train_a_synthesizer.py
@@ -116,7 +116,12 @@ def run():
             if st.button('Click here to start the training process', disabled=not valid_token):
                 model = RegularSynthesizer()
                 with st.spinner("Please wait while your synthesizer trains..."):
-                    model.fit(X=df)
+                    dtypes = {}
+                    for c in num_cols:
+                        dtypes[c] = 'numerical'
+                    for c in cat_cols:
+                        dtypes[c] = 'categorical'
+                    model.fit(X=df, dtypes=dtypes)
 
                 st.success('Synthesizer was trained succesfully!')
                 st.info(f"The trained model will be saved at {model_path}.")

--- a/src/ydata_synthetic/streamlit_app/pages/1_Train_a_synthesizer.py
+++ b/src/ydata_synthetic/streamlit_app/pages/1_Train_a_synthesizer.py
@@ -17,7 +17,7 @@ def get_available_models(type: Union[str, DataType]):
 
     dtype = DataType(type)
     if dtype == DataType.TABULAR:
-        models_list = [e.value.upper() for e in Model if e.value not in ['cgan', 'cwgangp']] + ['Fabric Regular Synthesizer']
+        models_list = [e.value.upper() for e in Model if e.value not in ['cgan', 'cwgangp']] + ['ydata-sdk Synthesizer']
     else:
         st.warning('Time-Series models are not yet supported .')
         models_list = ([''])
@@ -40,7 +40,7 @@ def run():
                 models_list = get_available_models(type=datatype)
                 model_name = st.selectbox('Select your model', models_list)
 
-        if model_name not in ['', 'Fabric Regular Synthesizer']:
+        if model_name not in ['', 'ydata-sdk Synthesizer']:
             st.text("Select your synthesizer model parameters")
             col1, col2 = st.columns(2)
             with col1:
@@ -84,7 +84,7 @@ def run():
 
 
 
-        if model_name == 'Fabric Regular Synthesizer':
+        if model_name == 'ydata-sdk Synthesizer':
             valid_token = False
             st.text("Model parameters")
             col1, col2 = st.columns(2)
@@ -102,7 +102,7 @@ def run():
                     st.text('❌ Invalid')
 
             if not valid_token:
-                st.error("""**Fabric Synthesizer requires a valid token.**    
+                st.error("""**ydata-sdk Synthesizer requires a valid token.**    
                 In case you do not have an account, please, create one at https://ydata.ai/ydata-fabric-free-trial.    
                 To obtain the token, please, login to https://fabric.ydata.ai.    
                 The token is available on the homepage once you are connected.

--- a/src/ydata_synthetic/streamlit_app/pages/2_Generate_synthetic_data.py
+++ b/src/ydata_synthetic/streamlit_app/pages/2_Generate_synthetic_data.py
@@ -1,17 +1,56 @@
 import streamlit as st
+import json
+import os
+
+from ydata.sdk.synthesizers import RegularSynthesizer
+from ydata.sdk.common.client import get_client
 
 from ydata_synthetic.streamlit_app.pages.functions.train import DataType
 from ydata_synthetic.streamlit_app.pages.functions.generate import load_model, generate_profile
 
 def run():
     st.subheader("Generate synthetic data from a trained model")
-
+    from_SDK = False
+    model_data = {}
+    valid_token = False
     col1, col2 = st.columns([4, 2])
     with col1:
         input_path = st.text_input("Provide the path to a trained model", value="trained_synth.pkl")
+        # Try to load as a JSON as SDK
+        try: 
+            f = open(input_path)
+            model_data = json.load(f)
+            from_SDK = True
+        except:
+            pass
+
+        if from_SDK:
+            token = st.text_input("SDK Token", type="password", value=model_data.get('token'))
+            os.environ['YDATA_TOKEN'] = token
+
+
     with col2:
         datatype = st.selectbox('Select your data type', (DataType.TABULAR.value,))
         datatype=DataType(datatype)
+
+        if from_SDK and 'YDATA_TOKEN' in os.environ:
+            st.write("##")
+            try:
+                get_client()
+                st.text('✅ Valid')
+                valid_token = True
+            except:
+                st.text('❌ Invalid')
+    
+    if from_SDK and 'token' in model_data and not valid_token:
+        st.warning("The token used during training is not valid anymore. Please, use a new token.")
+
+    if from_SDK and not valid_token:
+        st.error("""**Fabric Synthesizer requires a valid token.**    
+        In case you do not have an account, please, create one at https://ydata.ai/ydata-fabric-free-trial.    
+        To obtain the token, please, login to https://fabric.ydata.ai.    
+        The token is available on the homepage once you are connected.
+        """)
 
     col1, col2 = st.columns([4,2])
     with col1:
@@ -21,14 +60,18 @@ def run():
         sample_path = st.text_input("Synthetic samples file path", value='synthetic.csv')
 
     if st.button('Generate samples'):
-        #load a trained model
-        model = load_model(input_path=input_path,
-                           datatype=datatype)
+        if from_SDK:
+            model = RegularSynthesizer.get(uid=model_data.get('uid'))
 
-        st.success('Trained model was loaded. You can now generate synthetic samples')
+        else:
+            model = load_model(input_path=input_path, datatype=datatype)
+
+        st.success('The model was properly loaded and is now ready to generate synthetic samples!')
+
 
         #sample synthetic data
-        synth_data = model.sample(n_samples)
+        with st.spinner('Generating samples... This might take time.'):
+            synth_data = model.sample(n_samples)
         st.write(synth_data)
 
         #save the synthetic data samples to a given path

--- a/src/ydata_synthetic/streamlit_app/pages/2_Generate_synthetic_data.py
+++ b/src/ydata_synthetic/streamlit_app/pages/2_Generate_synthetic_data.py
@@ -39,7 +39,7 @@ def run():
                 get_client()
                 st.text('✅ Valid')
                 valid_token = True
-            except:
+            except Exception:
                 st.text('❌ Invalid')
     
     if from_SDK and 'token' in model_data and not valid_token:

--- a/src/ydata_synthetic/streamlit_app/pages/2_Generate_synthetic_data.py
+++ b/src/ydata_synthetic/streamlit_app/pages/2_Generate_synthetic_data.py
@@ -46,7 +46,7 @@ def run():
         st.warning("The token used during training is not valid anymore. Please, use a new token.")
 
     if from_SDK and not valid_token:
-        st.error("""**Fabric Synthesizer requires a valid token.**    
+        st.error("""**ydata-sdk Synthesizer requires a valid token.**    
         In case you do not have an account, please, create one at https://ydata.ai/ydata-fabric-free-trial.    
         To obtain the token, please, login to https://fabric.ydata.ai.    
         The token is available on the homepage once you are connected.


### PR DESCRIPTION
Add Fabric Regular Synthesizer to Streamlit app:

When Fabric Regular Synthesizer is selected, the input `SDK Token` is displayed and validated on the fly. If there is no token or the token is invalid, the following error and guidance is displayed:
![image](https://user-images.githubusercontent.com/1913007/226647506-0b710256-0c48-48c1-98ef-86aff2ca4050.png)

When a particular path is specified for a model, we check in real time if it is a local model or from the SDK. If it is from the SDK, we display the token field and automatically fill it with the value serialized during training:
![image](https://user-images.githubusercontent.com/1913007/226647929-b78b9077-a182-4a00-ae3f-046e16d35ff1.png)

As the token might become invalid in between, we allow the user to change it. If the token is present with the model file but invalid, we display it as well: 
![image](https://user-images.githubusercontent.com/1913007/226648452-af6a6377-13c3-4d9d-9212-ac7e776d7ce2.png)
