### PR TITLE
fix: update README.md to fix pip install typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The streamlit app is available form *v1.0.0* onwards, and supports the following
 #### Installation
 
 ```commandline
-pip install ydata-syntehtic[streamlit]
+pip install ydata-synthetic[streamlit]
 ```
 #### Quickstart
 Use the code snippet below in a python file (Jupyter Notebooks are not supported):


### PR DESCRIPTION
typo fix in pip install command in README.md (needed to be pip install ydata-synthetic[streamlit])